### PR TITLE
fix: update fact traits to be consistent

### DIFF
--- a/data/abilities/collection/001e21ea-61b5-4b78-b79e-9d5687d819bd.yml
+++ b/data/abilities/collection/001e21ea-61b5-4b78-b79e-9d5687d819bd.yml
@@ -15,12 +15,12 @@
     linux:
       sh:
         command:
-          './modbus_cli #{modbus.all.deviceip} --port #{modbus.all.deviceport} read_di #{modbus.read_di.start} #{modbus.read_di.count}'
+          './modbus_cli #{modbus.server.ip} --port #{modbus.server.port} read_di #{modbus.read.discrete.start} #{modbus.read.discrete.count}'
         payloads:
         - modbus_cli
     windows:
       psh:
         command:
-          '.\modbus_cli.exe #{modbus.all.deviceip} --port #{modbus.all.deviceport} read_di #{modbus.read_di.start} #{modbus.read_di.count}'
+          '.\modbus_cli.exe #{modbus.server.ip} --port #{modbus.server.port} read_di #{modbus.read.discrete.start} #{modbus.read.discrete.count}'
         payloads:
         - modbus_cli.exe

--- a/data/abilities/collection/3946b6da-c570-47cd-b63f-c13875297cb4.yml
+++ b/data/abilities/collection/3946b6da-c570-47cd-b63f-c13875297cb4.yml
@@ -15,12 +15,12 @@
     linux:
       sh:
         command:
-          './modbus_cli #{modbus.all.deviceip} --port #{modbus.all.deviceport} read_ir #{modbus.read_ir.start} #{modbus.read_ir.count}'
+          './modbus_cli #{modbus.server.ip} --port #{modbus.server.port} read_ir #{modbus.read.input.start} #{modbus.read.input.count}'
         payloads:
         - modbus_cli
     windows:
       psh:
         command:
-          '.\modbus_cli.exe #{modbus.all.deviceip} --port #{modbus.all.deviceport} read_ir #{modbus.read_ir.start} #{modbus.read_ir.count}'
+          '.\modbus_cli.exe #{modbus.server.ip} --port #{modbus.server.port} read_ir #{modbus.read.input.start} #{modbus.read.input.count}'
         payloads:
         - modbus_cli.exe

--- a/data/abilities/collection/bc8961a2-7534-4b2a-bbc3-2456f58243be.yml
+++ b/data/abilities/collection/bc8961a2-7534-4b2a-bbc3-2456f58243be.yml
@@ -10,17 +10,17 @@
   technique:
     attack_id: T0861
     name: Point & Tag Identification
-  repeatable: True
+  repeatable: true
   platforms:
     linux:
       sh:
         command:
-          './modbus_cli #{modbus.all.deviceip} --port #{modbus.all.deviceport} read_hr #{modbus.read_hr.start} #{modbus.read_hr.count}'
+          './modbus_cli #{modbus.server.ip} --port #{modbus.server.port} read_hr #{modbus.read.holding.start} #{modbus.read.holding.count}'
         payloads:
         - modbus_cli
     windows:
       psh:
         command:
-          '.\modbus_cli.exe #{modbus.all.deviceip} --port #{modbus.all.deviceport} read_hr #{modbus.read_hr.start} #{modbus.read_hr.count}'
+          '.\modbus_cli.exe #{modbus.server.ip} --port #{modbus.server.port} read_hr #{modbus.read.holding.start} #{modbus.read.holding.count}'
         payloads:
         - modbus_cli.exe

--- a/data/abilities/collection/d80b9cd5-b1d8-482a-a745-71d74f9d0885.yml
+++ b/data/abilities/collection/d80b9cd5-b1d8-482a-a745-71d74f9d0885.yml
@@ -15,12 +15,12 @@
     linux:
       sh:
         command:
-          './modbus_cli #{modbus.all.deviceip} --port #{modbus.all.deviceport} read_c #{modbus.read_c.start} #{modbus.read_c.count}'
+          './modbus_cli #{modbus.server.ip} --port #{modbus.server.port} read_c #{modbus.read.coil.start} #{modbus.read.coil.count}'
         payloads:
         - modbus_cli
     windows:
       psh:
         command:
-          '.\modbus_cli.exe #{modbus.all.deviceip} --port #{modbus.all.deviceport} read_c #{modbus.read_c.start} #{modbus.read_c.count}'
+          '.\modbus_cli.exe #{modbus.server.ip} --port #{modbus.server.port} read_c #{modbus.read.coil.start} #{modbus.read.coil.count}'
         payloads:
         - modbus_cli.exe

--- a/data/abilities/impact/056e6289-4cbf-417f-928a-d75125e4db4f.yml
+++ b/data/abilities/impact/056e6289-4cbf-417f-928a-d75125e4db4f.yml
@@ -15,12 +15,12 @@
     linux:
       sh:
         command:
-          './modbus_cli #{modbus.all.deviceip} --port #{modbus.all.deviceport} write_c #{modbus.write_c.start} #{modbus.write_c.value}'
+          './modbus_cli #{modbus.server.ip} --port #{modbus.server.port} write_c #{modbus.write.coil.start} #{modbus.write.coil.value}'
         payloads:
         - modbus_cli
     windows:
       psh:
         command:
-          '.\modbus_cli.exe #{modbus.all.deviceip} --port #{modbus.all.deviceport} write_c #{modbus.write_c.start} #{modbus.write_c.value}'
+          '.\modbus_cli.exe #{modbus.server.ip} --port #{modbus.server.port} write_c #{modbus.write.coil.start} #{modbus.write.coil.value}'
         payloads:
         - modbus_cli.exe

--- a/data/abilities/impact/0f16b341-9730-4553-b6d6-8eb8def02c81.yml
+++ b/data/abilities/impact/0f16b341-9730-4553-b6d6-8eb8def02c81.yml
@@ -15,12 +15,12 @@
     linux:
       sh:
         command:
-          './modbus_cli #{modbus.all.deviceip} --port #{modbus.all.deviceport} write_multi_r #{modbus.write_multi_r.start}  #{modbus.write_multi_r.value} #{modbus.write_multi_r.count}'
+          './modbus_cli #{modbus.server.ip} --port #{modbus.server.port} write_multi_r #{modbus.write.holding.start} #{modbus.write.holding.value} #{modbus.write.holding.count}'
         payloads:
         - modbus_cli
     windows:
       psh:
         command:
-          '.\modbus_cli.exe #{modbus.all.deviceip} --port #{modbus.all.deviceport} write_multi_r #{modbus.write_multi_r.start} #{modbus.write_multi_r.value} #{modbus.write_multi_r.count}'
+          '.\modbus_cli.exe #{modbus.server.ip} --port #{modbus.server.port} write_multi_r #{modbus.write.holding.start} #{modbus.write.holding.value} #{modbus.write.holding.count}'
         payloads:
         - modbus_cli.exe

--- a/data/abilities/impact/2a6e8c8e-f350-11ed-9156-23436b8f0e58.yml
+++ b/data/abilities/impact/2a6e8c8e-f350-11ed-9156-23436b8f0e58.yml
@@ -4,7 +4,7 @@
   name: Modbus Fuzz Registers
   description: |
     Procedure
-    Modbus Function 5 (0x05) Write Single Register
+    Modbus Function 6 (0x06) Write Single Register
 
     Writes random values to random registers over specified ranges. Addressing starts at 0 (e.g. registers 1-5 = addresses 0-4).
   tactic: impact
@@ -16,12 +16,12 @@
     linux:
       sh:
         command:
-          './modbus_cli #{modbus.all.deviceip} --port #{modbus.all.deviceport} fuzz_r #{modbus.fuzzreg.start} #{modbus.fuzzreg.end} #{modbus.fuzzreg.count} --min #{modbus.fuzzreg.min} --max #{modbus.fuzzreg.max} --wait #{modbus.fuzzreg.wait}'
+          './modbus_cli #{modbus.server.ip} --port #{modbus.server.port} fuzz_r #{modbus.fuzz.holding.start} #{modbus.fuzz.holding.end} #{modbus.fuzz.holding.count} --min #{modbus.fuzz.holding.min} --max #{modbus.fuzz.holding.max} --wait #{modbus.fuzz.holding.wait}'
         payloads:
         - modbus_cli
     windows:
       psh:
         command:
-         '.\modbus_cli.exe #{modbus.all.deviceip} --port #{modbus.all.deviceport} fuzz_r #{modbus.fuzzreg.start} #{modbus.fuzzreg.end} #{modbus.fuzzreg.count} --min #{modbus.fuzzreg.min} --max #{modbus.fuzzreg.max} --wait #{modbus.fuzzreg.wait}'
+         '.\modbus_cli.exe #{modbus.server.ip} --port #{modbus.server.port} fuzz_r #{modbus.fuzz.holding.start} #{modbus.fuzz.holding.end} #{modbus.fuzz.holding.count} --min #{modbus.fuzz.holding.min} --max #{modbus.fuzz.holding.max} --wait #{modbus.fuzz.holding.wait}'
         payloads:
         - modbus_cli.exe

--- a/data/abilities/impact/40f78a8f-2aaa-4b1b-872f-7c6b0f1ddf3e.yml
+++ b/data/abilities/impact/40f78a8f-2aaa-4b1b-872f-7c6b0f1ddf3e.yml
@@ -16,12 +16,12 @@
     linux:
       sh:
         command:
-          './modbus_cli #{modbus.all.deviceip} --port #{modbus.all.deviceport} fuzz_c #{modbus.fuzzcoil.start} #{modbus.fuzzcoil.end} #{modbus.fuzzcoil.count} --wait #{modbus.fuzzcoil.wait}'
+          './modbus_cli #{modbus.server.ip} --port #{modbus.server.port} fuzz_c #{modbus.fuzz.coil.start} #{modbus.fuzz.coil.end} #{modbus.fuzz.coil.count} --wait #{modbus.fuzz.coil.wait}'
         payloads:
         - modbus_cli
     windows:
       psh:
         command:
-         '.\modbus_cli.exe #{modbus.all.deviceip} --port #{modbus.all.deviceport} fuzz_c #{modbus.fuzzcoil.start} #{modbus.fuzzcoil.end} #{modbus.fuzzcoil.count} --wait #{modbus.fuzzcoil.wait}'
+         '.\modbus_cli.exe #{modbus.server.ip} --port #{modbus.server.port} fuzz_c #{modbus.fuzz.coil.start} #{modbus.fuzz.coil.end} #{modbus.fuzz.coil.count} --wait #{modbus.fuzz.coil.wait}'
         payloads:
         - modbus_cli.exe

--- a/data/abilities/impact/d6991b6b-d3b2-4398-ad3f-d736ae09acf9.yml
+++ b/data/abilities/impact/d6991b6b-d3b2-4398-ad3f-d736ae09acf9.yml
@@ -15,12 +15,12 @@
     linux:
       sh:
         command:
-          './modbus_cli #{modbus.all.deviceip} --port #{modbus.all.deviceport} write_r #{modbus.write_r.start} #{modbus.write_r.value}'
+          './modbus_cli #{modbus.server.ip} --port #{modbus.server.port} write_r #{modbus.write.holding.start} #{modbus.write.holding.value}'
         payloads:
         - modbus_cli
     windows:
       psh:
         command:
-          '.\modbus_cli.exe #{modbus.all.deviceip} --port #{modbus.all.deviceport} write_r #{modbus.write_r.start} #{modbus.write_r.value}'
+          '.\modbus_cli.exe #{modbus.server.ip} --port #{modbus.server.port} write_r #{modbus.write.holding.start} #{modbus.write.holding.value}'
         payloads:
         - modbus_cli.exe

--- a/data/abilities/impact/fe321da2-e183-44a3-b423-b8cba9a8bda0.yml
+++ b/data/abilities/impact/fe321da2-e183-44a3-b423-b8cba9a8bda0.yml
@@ -15,12 +15,12 @@
     linux:
       sh:
         command:
-          './modbus_cli #{modbus.all.deviceip} --port #{modbus.all.deviceport} write_multi_c #{modbus.write_multi_c.start}  #{modbus.write_multi_c.value} #{modbus.write_multi_c.count}'
+          './modbus_cli #{modbus.server.ip} --port #{modbus.server.port} write_multi_c #{modbus.write.coil.start} #{modbus.write.coil.value} #{modbus.write.coil.count}'
         payloads:
         - modbus_cli
     windows:
       psh:
         command:
-          '.\modbus_cli.exe #{modbus.all.deviceip} --port #{modbus.all.deviceport} write_multi_c #{modbus.write_multi_c.start} #{modbus.write_multi_c.value} #{modbus.write_multi_c.count}'
+          '.\modbus_cli.exe #{modbus.server.ip} --port #{modbus.server.port} write_multi_c #{modbus.write.coil.start} #{modbus.write.coil.value} #{modbus.write.coil.count}'
         payloads:
         - modbus_cli.exe

--- a/data/sources/0033b644-a615-4eff-bcf3-178e9b17adc3.yml
+++ b/data/sources/0033b644-a615-4eff-bcf3-178e9b17adc3.yml
@@ -1,25 +1,19 @@
 ---
 
 id: 0033b644-a615-4eff-bcf3-178e9b17adc3
-name: Sample Modbus Facts
+name: Modbus Sample Facts
 facts:
-- trait: device.modbus.ip
+- trait: modbus.server.ip
   value: 127.0.0.1
-- trait: device.modbus.port
-  value: 5020
-- trait: modbus.read_di.start
+- trait: modbus.server.port
+  value: 502
+- trait: modbus.read.discrete.start
+  value: 10000
+- trait: modbus.read.discrete.count
+  value: 1
+- trait: modbus.write.coil.start
   value: 0
-- trait: modbus.read_di.count
-  value: 1
-- trait: modbus.write.start
-  value: 1
-- trait: modbus.write.value
-  value: 1
-- trait: modbus.toggle.start
-  value: 1
-- trait: modbus.toggle.end
-  value: 11
-- trait: modbus.toggle.count
-  value: 10
+- trait: modbus.write.coil.value
+  value: 0
 rules: []
 relationships: []

--- a/docs/modbus.md
+++ b/docs/modbus.md
@@ -84,62 +84,60 @@ Key:
 - [**X**] = Ability uses this fact
 
 
-| Fact Name/Ability Used By | Read Coil	 | Read Discrete Input | Read Input Register | Read Holding Register |
-|---------                  |---------   |---------	           |---------	         |---------              |
-| modbus.all.deviceip       | [**X**]    | [**X**]             |[**X**]              | [**X**]               |
-| modbus.all.deviceport     | [**X**]    | [**X**]             |[**X**]              | [**X**]               |
-| modbus.read_c.start       | [**X**]    | [-]                 |[-]                  | [-]                   |
-| modbus.read_c.count       | [**X**]    | [-]                 |[-]                  | [-]                   |
-| modbus.read_di.start      | [-]        | [**X**]             |[-]                  | [-]                   |
-| modbus.read_di.count      | [-]        | [**X**]             |[-]                  | [-]                   |
-| modbus.read_ir.start      | [-]        | [-]                 |[**X**]              | [-]                   |
-| modbus.read_ir.count      | [-]        | [-]                 |[**X**]              | [-]                   |
-| modbus.read_hr.start      | [-]        | [-]                 |[-]                  | [**X**]               |
-| modbus.read_hr.count      | [-]        | [-]                 |[-]                  | [**X**]               |
+| Fact Name/Ability Used By  | Read Coil  | Read Discrete Input | Read Input Register | Read Holding Register |
+|---------                   |---------   |---------            |---------	          |---------              |
+| modbus.server.ip           | [**X**]    | [**X**]             |[**X**]              | [**X**]               |
+| modbus.server.port         | [**X**]    | [**X**]             |[**X**]              | [**X**]               |
+| modbus.read.coil.start     | [**X**]    | [-]                 |[-]                  | [-]                   |
+| modbus.read.coil.count     | [**X**]    | [-]                 |[-]                  | [-]                   |
+| modbus.read.discrete.start | [-]        | [**X**]             |[-]                  | [-]                   |
+| modbus.read.discrete.count | [-]        | [**X**]             |[-]                  | [-]                   |
+| modbus.read.input.start    | [-]        | [-]                 |[**X**]              | [-]                   |
+| modbus.read.input.count    | [-]        | [-]                 |[**X**]              | [-]                   |
+| modbus.read.holding.start  | [-]        | [-]                 |[-]                  | [**X**]               |
+| modbus.read.holding.count  | [-]        | [-]                 |[-]                  | [**X**]               |
 
-| Fact Name/Ability Used By | Write Coil | Write Register | Write Multiple Coils | Write Multiple Registers |
-|---------                  |---------   |---------	      |---------	         |---------                 |
-| modbus.all.deviceip       | [**X**]    | [**X**]        |[**X**]               | [**X**]                  |
-| modbus.all.deviceport     | [**X**]    | [**X**]        |[**X**]               | [**X**]                  |
-| modbus.write_c.start      | [**X**]    | [-]            |[-]                   | [-]                      |
-| modbus.write_c.value      | [**X**]    | [-]            |[-]                   | [-]                      |
-| modbus.read_di.start      | [-]        | [**X**]        |[-]                   | [-]                      |
-| modbus.read_di.count      | [-]        | [**X**]        |[-]                   | [-]                      |
-| modbus.read_ir.start      | [-]        | [-]            |[**X**]               | [-]                      |
-| modbus.read_ir.count      | [-]        | [-]            |[**X**]               | [-]                      |
-| modbus.read_hr.start      | [-]        | [-]            |[-]                   | [**X**]                  |
-| modbus.read_hr.count      | [-]        | [-]            |[-]                   | [**X**]                  |
+| Fact Name/Ability Used By   | Write Coil | Write Register | Write Multiple Coils | Write Multiple Registers |
+|---------                    |---------   |---------	    |---------	           |---------                 |
+| modbus.server.ip            | [**X**]    | [**X**]        |[**X**]               | [**X**]                  |
+| modbus.server.port          | [**X**]    | [**X**]        |[**X**]               | [**X**]                  |
+| modbus.write.coil.start     | [**X**]    | [-]            |[**X**]               | [-]                      |
+| modbus.write.coil.value     | [**X**]    | [-]            |[**X**]               | [-]                      |
+| modbus.write.coil.count     | [-]        | [-]            |[**X**]               | [-]                      |
+| modbus.write.holding.start  | [-]        | [**X**]        |[-]                   | [**X**]                  |
+| modbus.write.holding.value  | [-]        | [**X**]        |[-]                   | [**X**]                  |
+| modbus.write.holding.count  | [-]        | [-]            |[-]                   | [**X**]                  |
 
 | Fact Name/Ability Used By | Fuzz Coils | Fuzz Registers|
 |---------                  |---------   |---------	     |
-| modbus.all.deviceip       | [**X**]    | [**X**]       |
-| modbus.all.deviceport     | [**X**]    | [**X**]       |
-| modbus.fuzzcoil.start     | [**X**]    | [-]           |
-| modbus.fuzzcoil.end       | [**X**]    | [-]           |
-| modbus.fuzzcoil.count     | [**X**]    | [-]           |
-| modbus.fuzzcoil.wait      | [**X**]    | [-]           |
-| modbus.fuzzreg.start      | [-]        | [**X**]       |
-| modbus.fuzzreg.end        | [-]        | [**X**]       |
-| modbus.fuzzreg.count      | [-]        | [**X**]       |
-| modbus.fuzzreg.min        | [-]        | [**X**]       |
-| modbus.fuzzreg.max        | [-]        | [**X**]       |
-| modbus.fuzzreg.wait       | [-]        | [**X**]       |
+| modbus.server.ip          | [**X**]    | [**X**]       |
+| modbus.server.port        | [**X**]    | [**X**]       |
+| modbus.fuzz.coil.start    | [**X**]    | [-]           |
+| modbus.fuzz.coil.end      | [**X**]    | [-]           |
+| modbus.fuzz.coil.count    | [**X**]    | [-]           |
+| modbus.fuzz.coil.wait     | [**X**]    | [-]           |
+| modbus.fuzz.holding.start | [-]        | [**X**]       |
+| modbus.fuzz.holding.end   | [-]        | [**X**]       |
+| modbus.fuzz.holding.count | [-]        | [**X**]       |
+| modbus.fuzz.holding.min   | [-]        | [**X**]       |
+| modbus.fuzz.holding.max   | [-]        | [**X**]       |
+| modbus.fuzz.holding.wait  | [-]        | [**X**]       |
 
 ####  Sample Facts - Modbus
     ...
     name: Modbus Sample Facts
     facts:
-    - trait: modbus.all.deviceip
+    - trait: modbus.server.ip
       value: 192.168.0.1
-    - trait: modbus.all.deviceport
+    - trait: modbus.server.port
       value: 5020
-	- trait: modbus.fuzzcoil.start
+	- trait: modbus.fuzz.coil.start
 	  value: 10
-	- trait: modbus.fuzzcoil.end
+	- trait: modbus.fuzz.coil.end
 	  value: 15
-	- trait: modbus.fuzzcoil.count
+	- trait: modbus.fuzz.coil.count
 	  value: 100
-	- trait: modbus.fuzzcoil.wait
+	- trait: modbus.fuzz.coil.wait
 	  value: 1
     ...
 


### PR DESCRIPTION
The fact traits used by the Modbus abilities were not consistent with the sample traits, nor were they consistent with the traits used by the other two OT plugins - `dnp3` and `bacnet`.

This PR attempts to make them consistent and easier to follow. For example, it was unclear what `modbus.all.deviceip` meant (specifically, the `all` portion). Using `modbus.server.ip` is more clear, and is also in line with how the `dnp3` plugin references fact traits.